### PR TITLE
Remove metaclass pattern from dependency management PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,8 +166,8 @@ All PRs triger a CI job to run linting, type checking, tests, and build docs. Th
 ## Optional Dependencies
 
 Alibi uses optional dependencies to allow users to avoid installing large or challenging to install dependencies. Alibi 
-manages modularity of components that depend on optional dependencies using the `import_optional` defined in 
-`alibi/utils/missing_optional_dependency.py`. This replaces the dependency with a dummy class that raises an error when 
+manages modularity of components that depend on optional dependencies using the `import_optional` function defined in 
+`alibi/utils/missing_optional_dependency.py`. This replaces the dependency with a dummy object that raises an error when
 called. If you are working on public functionality that is dependent on an optional dependency you should expose the 
 functionality via the relevant `__init__.py` file by importing it there using the `optional_import` function. Currently,
 optional dependencies are tested by importing all the public functionality and checking that the correct errors are 
@@ -177,8 +177,7 @@ you will need to:
 
 1. Add it to `extras_require` in `setup.py`.
 2. Create a new `tox` environment in `setup.cfg` with the new dependency.
-3. Define a new MissingDependency class in `alibi/utils/missing_optional_dependency.py` and integrate it with the 
-   `import_optional` function.
+3. Add a new dependency name to `ERROR_TYPES` in `alibi/utils/missing_optional_dependency.py`. 
 4. Make sure any public functionality is protected by the `import_optional` function.
 5. Make sure the new dependency is tested in `alibi/tests/test_dep_mangement.py`.
 
@@ -209,6 +208,8 @@ objects imported with this function can lead to misspecification of types as `An
 more restrictive. If you want to type a variable using a class that depends on an optional dependency then you should 
 use the `TYPE_CHECKING` to import it instead. For instance:
   ```py
+  from typing import TYPE_CHECKING
+
   if TYPE_CHECKING:
     # Import for type checking. This will be type LanguageModel. Note import is from implementation file.
     from alibi.utils.lang_model import LanguageModel

--- a/alibi/explainers/anchors/anchor_tabular_distributed.py
+++ b/alibi/explainers/anchors/anchor_tabular_distributed.py
@@ -286,7 +286,7 @@ class DistributedAnchorTabular(AnchorTabular):
             d_samplers.append(
                 ####-Changed-#### # noqa
                 # DistributedAnchorTabular.ray.remote(RemoteSampler).remote(
-                ray.remote(RemoteSampler).remote(
+                ray.remote(RemoteSampler).remote(  # type: ignore[call-overload]
                     *(train_data_id, d_train_data_id, sampler)
                 )
                 ###############

--- a/alibi/explainers/anchors/anchor_text.py
+++ b/alibi/explainers/anchors/anchor_text.py
@@ -222,7 +222,7 @@ class AnchorText(Explainer):
     def _validate_kwargs(self,
                          sampling_strategy: str,
                          nlp: Optional['spacy.language.Language'] = None,
-                         language_model: Optional[LanguageModel] = None,
+                         language_model: Optional['LanguageModel'] = None,
                          **kwargs: Any) -> Tuple[dict, dict]:
 
         # set sampling method

--- a/alibi/tests/test_dep_management.py
+++ b/alibi/tests/test_dep_management.py
@@ -41,10 +41,10 @@ def check_correct_dependencies(
         The name of the optional dependency that is being tested.
     """
     lib_obj = [obj for obj in dir(module) if not obj.startswith('_')]
-    for item in lib_obj:
-        item = getattr(module, item)
-        if not isinstance(item, ModuleType) and hasattr(item, '__name__'):
-            pass_contexts = dependencies[item.__name__]  # type: ignore
+    for item_name in lib_obj:
+        item = getattr(module, item_name)
+        if not isinstance(item, ModuleType):
+            pass_contexts = dependencies[item_name]  # type: ignore
             if opt_dep in pass_contexts or 'default' in pass_contexts or opt_dep == 'all':
                 with pytest.raises(AttributeError):
                     item.test  # type: ignore # noqa

--- a/alibi/utils/missing_optional_dependency.py
+++ b/alibi/utils/missing_optional_dependency.py
@@ -61,7 +61,7 @@ class MissingDependency:
         raise ImportError(self.err_msg) from self.err
 
     def __call__(self, *args, **kwargs):
-        """Raise an error if initialized."""
+        """If called, raise an error."""
         raise ImportError(self.err_msg) from self.err
 
 

--- a/alibi/utils/tests/mocked_opt_dep.py
+++ b/alibi/utils/tests/mocked_opt_dep.py
@@ -1,0 +1,10 @@
+import non_existent_module  # noqa: F401
+
+
+class MockedClassWithoutRequiredDeps:
+    def __init__(self):
+        self.opt_dep = "opt_dep"
+
+
+def mocked_function_without_required_deps():
+    pass

--- a/alibi/utils/tests/test_import_optional.py
+++ b/alibi/utils/tests/test_import_optional.py
@@ -8,11 +8,11 @@ class TestImportOptional:
 
     def setup_method(self):
         # mock missing dependency error for non existent module
-        ERROR_TYPES['thispackagedoesnotexist'] = MissingDependency
+        ERROR_TYPES.add('non_existent_module')
 
     def teardown_method(self):
         # remove mock missing dependency error for other tests
-        del ERROR_TYPES['thispackagedoesnotexist']
+        ERROR_TYPES.remove('non_existent_module')
 
     def test_import_optional_module(self):
         """Test import_optional correctly imports installed module."""
@@ -30,31 +30,31 @@ class TestImportOptional:
 
     def test_import_optional_module_missing(self):
         """Test import_optional correctly replaces module that doesn't exist with MissingDependency."""
-        package = import_optional('thispackagedoesnotexist')
+        package = import_optional('alibi.utils.tests.mocked_opt_dep')
         assert isinstance(package, MissingDependency)
         with pytest.raises(ImportError) as err:
             package.__version__  # noqa
-        assert 'thispackagedoesnotexist' in str(err.value)
-        assert 'pip install alibi[all]' in str(err.value)
+        assert 'alibi.utils.tests.mocked_opt_dep' in str(err.value)
+        assert 'pip install alibi[non_existent_module]' in str(err.value)
 
         with pytest.raises(ImportError) as err:
             package(0, 'test')  # noqa
-        assert 'thispackagedoesnotexist' in str(err.value)
-        assert 'pip install alibi[all]' in str(err.value)
+        assert 'alibi.utils.tests.mocked_opt_dep' in str(err.value)
+        assert 'pip install alibi[non_existent_module]' in str(err.value)
 
     def test_import_optional_names_missing(self):
         """Test import_optional correctly replaces names from module that doesn't exist with MissingDependencies."""
-        nonexistent_function_1, nonexistent_function_2 = import_optional(
-            'thispackagedoesnotexist',
-            names=['nonexistent_function_1', 'nonexistent_function_2'])
-        assert isinstance(nonexistent_function_1, MissingDependency)
+        MockedClassWithoutRequiredDeps, mocked_function_without_required_deps = import_optional(
+            'alibi.utils.tests.mocked_opt_dep',
+            names=['MockedClassWithoutRequiredDeps', 'mocked_function_without_required_deps'])
+        assert isinstance(MockedClassWithoutRequiredDeps, MissingDependency)
         with pytest.raises(ImportError) as err:
-            nonexistent_function_1.__version__  # noqa
-        assert 'nonexistent_function_1' in str(err.value)
-        assert 'pip install alibi[all]' in str(err.value)
+            MockedClassWithoutRequiredDeps.__version__  # noqa
+        assert 'MockedClassWithoutRequiredDeps' in str(err.value)
+        assert 'pip install alibi[non_existent_module]' in str(err.value)
 
-        assert isinstance(nonexistent_function_2, MissingDependency)
+        assert isinstance(mocked_function_without_required_deps, MissingDependency)
         with pytest.raises(ImportError) as err:
-            nonexistent_function_2.__version__  # noqa
-        assert 'nonexistent_function_2' in str(err.value)
-        assert 'pip install alibi[all]' in str(err.value)
+            mocked_function_without_required_deps.__version__  # noqa
+        assert 'mocked_function_without_required_deps' in str(err.value)
+        assert 'pip install alibi[non_existent_module]' in str(err.value)


### PR DESCRIPTION
## Removes metaclass pattern from dep-management PR.

`Optional_import` now returns an instance of the missing dependency class. This doesn't throw an error when passed as a forward reference to `Union` and as type checking only occurs in the dev environment we can import the true objects dependent on the `TYPE_CHECKING` flag. 

___

### Note:

Somewhat confusingly the `MissingDependency` instance as implemented here actully won't fail if passed to `Union`. This seems to be because of the `__call__` method override on the class. For instance, the following will throw an error:

```py
from typing import Union


class A:
  pass

a = A()

Union[a]
```

Whereas this will not:

```py
from typing import Union


class A:
  def __init__(self):
    pass

  def __call__(self):
    pass

a = A()

Union[a]
```

I'm not sure why exactly this behaviour occurs but we do require the `__call__` method override on the `MissingDependency` class. This is because a user might try to initialize an imported explainer and get an `object is not callable` error rather than the Import error. I was tempted to see if we could use this to navigate the `Union` issue altogether and thus remove the conditional import on `TYPE_CHECKING` but that seems a bit hacky.
